### PR TITLE
Port to Processing 4

### DIFF
--- a/PianoVisualizer.pde
+++ b/PianoVisualizer.pde
@@ -1,4 +1,6 @@
-import themidibus.*; //Import the midibus library
+import processing.javafx.*; // Import the JavaFX library
+import themidibus.*; // Import the midibus library
+
 MidiBus myBus; // The MidiBus
 
 boolean nowPedaling = false; // is it pedaling?（不要動）
@@ -8,7 +10,7 @@ int[] isPedaled = new int[128]; // what notes are pedaled (1 or 0)（不要動�
 color keyOnColor; // set it in setup()
 color pedaledColor; // set it in setup()
 
-int[] isBlack = {0, 11, 0, 13, 0, 0, 11, 0, 12, 0, 13, 0}; // 是黑鍵嗎？是的話，相對左方的白鍵位移多少？(default: {0, 11, 0, 13, 0, 0, 11, 0, 12, 0, 13, 0}）
+int[] isBlack = {0, 11, 0, 13, 0, 0, 11, 0, 12, 0, 13, 0}; // 是黑鍵嗎？是的話，相對左方的白鍵位移多少？（default: {0, 11, 0, 13, 0, 0, 11, 0, 12, 0, 13, 0}）
 int border = 3; // 左方留空幾個畫素？(default: 3)
 int whiteKeyWidth = 20; // 白鍵多寬？(default: 20)
 int whiteKeySpace = 1; // 白鍵間的縫隙多寬？(default: 1)
@@ -32,7 +34,8 @@ void setup() {
   frameRate(60);
   initKeys();
   MidiBus.list(); // 啟動時會列出 MIDI 輸入/輸出 設備，記下你想用的 MIDI 輸入編號，設定在下一行。
-  myBus = new MidiBus(this, 4, -1); // 編輯「this 後面那個數字」選擇 MIDI 輸入設備。
+  MidiReceiver receiver = new MidiReceiver();
+  myBus = new MidiBus(receiver, 999, -1); // 編輯「receiver 後面那個數字」選擇 MIDI 輸入設備。
 }
 
 void draw() {
@@ -108,36 +111,40 @@ void drawBlackKeys() {
   }
 }
 
-void noteOn(int channel, int pitch, int velocity) {
-  // Receive a noteOn
-  isKeyOn[pitch] = 1;
-  isFilled[pitch] = 100;
-  if (nowPedaling) {
-    isPedaled[pitch] = 1;
-  }
-}
+public class MidiReceiver {
 
-void noteOff(int channel, int pitch, int velocity) {
-  // Receive a noteOff
-  isKeyOn[pitch] = 0;
-  isFilled[pitch] = 0;
-}
-
-void controllerChange(int channel, int number, int value) {
-  // Receive a controllerChange
-  if (number == 64 && value >= 64) {
-    nowPedaling = true;
-    for (int i = 0; i<128; i++) {
-      // copy key on to pedal
-      isPedaled[i] = isKeyOn[i];
+  void noteOn(int channel, int pitch, int velocity) {
+    // Receive a noteOn
+    isKeyOn[pitch] = 1;
+    isFilled[pitch] = 100;
+    if (nowPedaling) {
+      isPedaled[pitch] = 1;
     }
   }
 
-  if (number == 64 && value < 64) {
-    nowPedaling = false;
-    for (int i = 0; i<128; i++) {
-      // reset isPedaledlin
-      isPedaled[i] = 0;
+  void noteOff(int channel, int pitch, int velocity) {
+    // Receive a noteOff
+    isKeyOn[pitch] = 0;
+    isFilled[pitch] = 0;
+  }
+
+  void controllerChange(int channel, int number, int value) {
+    // Receive a controllerChange
+    if (number == 64 && value >= 64) {
+      nowPedaling = true;
+      for (int i = 0; i<128; i++) {
+        // copy key on to pedal
+        isPedaled[i] = isKeyOn[i];
+      }
+    }
+
+    if (number == 64 && value < 64) {
+      nowPedaling = false;
+      for (int i = 0; i<128; i++) {
+        // reset isPedaledlin
+        isPedaled[i] = 0;
+      }
     }
   }
+
 }

--- a/README.md
+++ b/README.md
@@ -2,8 +2,16 @@
 Minimal piano keyboard visualizer for your videos and livestreams!
 
 How to use:
-1. Install Processing 3
-1. Install The MidiBus Library
-1. Open PianoVisualizer.pde in Processing 3
-1. Edit source code to select MIDI input port
-1. Enjoy!
+1. Install [Processing 4](https://processing.org/).
+
+   Also available on Homebrew for macOS:
+   ```bash
+   brew install processing
+   ```
+1. Open Processing 4, select Sketch → Import Library… → Manage Libraries…
+
+   Install both “JavaFX” and “The MidiBus”.
+1. Open `PianoVisualizer.pde`.
+1. Press the ▶️ button once. The program will fail to work as expected, but you will see a list of MIDI input/output ports in the Console panel.
+1. Go to Line 38, change the number “999” to your actual MIDI input port number.
+1. Press the ▶️ button again and enjoy!


### PR DESCRIPTION
Since Processing 4, The MidiBus library requires we to write `noteOn`/`noteOff` methods in a separate class.
(Related bug report: https://github.com/sparks/themidibus/issues/28)

I made the change and also updated the `Readme.md` file with more detailed instructions.

---

自從 Processing 4，The MidiBus 庫要求我們把 `noteOn`/`noteOff` 寫到單獨的一個類別內。
（相關的 bug 報告：<https://github.com/sparks/themidibus/issues/28>）

我做了相關更改，並且為 `Readme.md` 檔案加入了更詳細的說明。